### PR TITLE
azd provisioning

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -13,27 +13,7 @@ services:
     project: ./src/frontend
     dist: dist
     language: ts
-    host: staticwebapp
-    hooks:
-      # Creates a temporary `.env.local` file for the build command. Vite will automatically use it during build.
-      # The expected/required values are mapped to the infrastructure outputs.
-      # .env.local is ignored by git, so it will not be committed if, for any reason, if deployment fails.
-      # see: https://vitejs.dev/guide/env-and-mode
-      # Note: Notice that dotenv must be a project dependency for this to work. See package.json.
-      prepackage:
-        windows:
-          shell: pwsh
-          run: 'set NODE_OPTIONS=--max_old_space_size=8192 && echo "VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=""$env:APPLICATIONINSIGHTS_CONNECTION_STRING""" >> .env.local'
-        posix:
-          shell: sh
-          run: 'export NODE_OPTIONS=--max_old_space_size=8192 && echo VITE_APPLICATIONINSIGHTS_CONNECTION_STRING=\"$APPLICATIONINSIGHTS_CONNECTION_STRING\" >> .env.local'    
-      postdeploy:
-        windows:
-          shell: pwsh
-          run: 'rm .env.local'
-        posix:
-          shell: sh
-          run: 'rm .env.local'
+    host: staticwebapp    
   api:
     project: ./src/backend
     language: python

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -28,6 +28,7 @@ param openAIDeploymentName string = 'chat'
 param openAIModelName string = 'gpt-4o'
 param embeddingDeploymentName string = 'embedding'
 param embeddingModelName string = 'text-embedding-ada-002'
+param openAiVersion string = '2024-02-15-preview'
 
 @description('Id of the user or app to assign application roles')
 param principalId string = ''
@@ -175,6 +176,8 @@ output BACKEND_URI string = api.outputs.SERVICE_API_URI
 // openai
 output AZURE_OPENAI_ENDPOINT string = openAi.outputs.endpoint
 output AZURE_OPENAI_API_DEPLOYMENT_NAME string = openAIDeploymentName
+output AZURE_OPENAI_API_VERSION string = openAiVersion
+output AZURE_OPENAI_API_KEY string = openAi.outputs.key
 output AZURE_OPENAI_MODEL_NAME string = openAIModelName
 output AZURE_OPENAI_EMBEDDING_NAME string = embeddingDeploymentName
 output USE_SUPERVISOR bool = useSupervisor

--- a/src/backend/functions/conversation.py
+++ b/src/backend/functions/conversation.py
@@ -65,6 +65,7 @@ async def converse(req: func.HttpRequest) -> func.HttpResponse:
                 tasks to the appropriate agent based on the user’s requests and ensure
                 seamless coordination between the agents.""",
                 agents,
+                llm
             )
 
             langchain_messages: List[BaseMessage] = await supervisor.arun(

--- a/src/backend/services/supervisor.py
+++ b/src/backend/services/supervisor.py
@@ -27,13 +27,14 @@ class Supervisor:
 
         members = [agent_name for agent_name, agent in agents.items()]
 
-        system_prompt = (
-            "You are a supervisor tasked with managing a conversation between the"
-            " following workers:  {members}. Given the following user request,"
-            " respond with the worker to act next. Each worker will perform a"
-            " task and respond with their results and status. When finished,"
-            " respond with FINISH."
-        )
+        if len(system_prompt.strip()) == 0:
+            system_prompt = (
+                "You are a supervisor tasked with managing a conversation between the"
+                " following workers:  {members}. Given the following user request,"
+                " respond with the worker to act next. Each worker will perform a"
+                " task and respond with their results and status. When finished,"
+                " respond with FINISH."
+            )
 
         # Our team supervisor is an LLM node. It just picks the next agent to process
         # and decides when the work is completed


### PR DESCRIPTION
This pull request includes several changes across different files to enhance functionality and simplify configuration. The most important changes include removing unnecessary hooks from `azure.yaml`, adding a new parameter and outputs in `infra/main.bicep`, and updating backend services to handle empty prompts and include additional arguments.

### Configuration Updates:

* [`azure.yaml`](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L17-L36): Removed `prepackage` and `postdeploy` hooks that created and deleted a temporary `.env.local` file for the build command.
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R31): Added `param openAiVersion string = '2024-02-15-preview'` to define the OpenAI version.
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R179-R180): Added outputs `AZURE_OPENAI_API_VERSION` and `AZURE_OPENAI_API_KEY` to expose the OpenAI version and API key.

### Backend Enhancements:

* [`src/backend/functions/conversation.py`](diffhunk://#diff-7278e02398620e9912052859f6998520e0b5202b7065f4f9d4eb30237d671323R68): Added `llm` to the `supervisor` call to pass the language model.
* [`src/backend/services/supervisor.py`](diffhunk://#diff-a6b9fd35f4ae45f32f866da6582885b17488a868e9ffbae6bb6de6dc5d7b4dd7R30): Added a check to handle empty `system_prompt` by setting a default prompt.